### PR TITLE
Refactor twitch code

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "aws-sdk": "^2.678.0",
     "discord.js": "^12.2.0",
     "dotenv": "^8.0.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.8",
+    "node-fetch": "^1.1.0",
     "source-map-support": "^0.5.12",
     "tmi.js": "^1.5.0",
     "twitch-webhook": "^1.2.4",
@@ -30,7 +29,6 @@
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
     "@types/node": "^12.0.6",
-    "@types/request-promise-native": "^1.0.17",
     "@types/tmi.js": "^1.4.0",
     "@types/twitter": "^1.7.0",
     "@types/yup": "^0.26.14",

--- a/src/beastie/commands/awesomeness/awesomeness.ts
+++ b/src/beastie/commands/awesomeness/awesomeness.ts
@@ -11,7 +11,7 @@ const execute = async (context: CommandContext): Promise<string> => {
 
   let twitchId: string = context.twitchId;
   if (context.para1) {
-    twitchId = (await broadcaster.getProfile())?.id;
+    twitchId = (await getTwitchProfile(context.para1))?.id;
     if (!twitchId) {
       return "Invalid twitch username supplied.";
     }

--- a/src/beastie/commands/awesomeness/awesomeness.ts
+++ b/src/beastie/commands/awesomeness/awesomeness.ts
@@ -1,8 +1,8 @@
-import { getTwitchId } from "../../../utils";
 import { BeastieLogger } from "../../../utils/Logging";
 import { CommandModule } from "../index";
 import CommandContext from "../utils/commandContext";
 import { getAwesomeness } from "../../../services/db";
+import { broadcaster } from "../../../services/twitch/TwitchAPI";
 
 const execute = async (context: CommandContext): Promise<string> => {
   if (context.platform == "discord" && !context.para1) {
@@ -11,7 +11,7 @@ const execute = async (context: CommandContext): Promise<string> => {
 
   let twitchId: string = context.twitchId;
   if (context.para1) {
-    twitchId = await getTwitchId(context.para1);
+    twitchId = (await broadcaster.getProfile())?.id;
     if (!twitchId) {
       return "Invalid twitch username supplied.";
     }

--- a/src/beastie/commands/awesomeness/awesomeness.ts
+++ b/src/beastie/commands/awesomeness/awesomeness.ts
@@ -2,7 +2,7 @@ import { BeastieLogger } from "../../../utils/Logging";
 import { CommandModule } from "../index";
 import CommandContext from "../utils/commandContext";
 import { getAwesomeness } from "../../../services/db";
-import { broadcaster } from "../../../services/twitch/TwitchAPI";
+import { getTwitchProfile } from "../../../services/twitch/TwitchAPI";
 
 const execute = async (context: CommandContext): Promise<string> => {
   if (context.platform == "discord" && !context.para1) {

--- a/src/beastie/commands/awesomeness/bonusall.ts
+++ b/src/beastie/commands/awesomeness/bonusall.ts
@@ -9,7 +9,7 @@ const execute = async (context: CommandContext): Promise<string> => {
   }
 
   try {
-    return updateChattersAwesomeness(context.para1);
+    return updateChattersAwesomeness(parseInt(context.para1, 10));
   } catch (error) {
     BeastieLogger.warn(`updateChattersAwesomeness ERROR: ${error}`);
   }

--- a/src/beastie/commands/hello.ts
+++ b/src/beastie/commands/hello.ts
@@ -1,10 +1,11 @@
 import {
-  beastieFaceTwitchEmotes,
-  beastieFaceDiscordEmotes
+  beastieFaceDiscordEmotes,
+  beastieFaceTwitchEmotes
 } from "../../utils/values";
-import { isBroadcaster, isGuildMaster } from "../../utils";
+import { isGuildMaster } from "../../utils";
 import { CommandModule } from "./index";
 import CommandContext from "./utils/commandContext";
+import { isBroadcaster } from "../../services/twitch/TwitchAPI";
 
 const execute = async (context: CommandContext): Promise<string> => {
   let beastieGreeting = "Hello";

--- a/src/beastie/commands/index.ts
+++ b/src/beastie/commands/index.ts
@@ -35,7 +35,8 @@ export const commandModules: CommandModule[] = [
   require("./awesomeness/awesomeness").default,
   require("./informational/about").default,
   require("./informational/discord").default,
-  require("./informational/twitch").default
+  require("./informational/twitch").default,
+  require("./informational/trello").default
 ];
 export const subscriberCommandModules: CommandModule[] = [];
 export const moderatorCommandModules: CommandModule[] = [

--- a/src/beastie/commands/informational/about.ts
+++ b/src/beastie/commands/informational/about.ts
@@ -9,4 +9,6 @@ const cmdModule = new CommandModule(
   new Set(["aboutus", "aboutteam", "abouttheteam", "aboutteamtalima"]),
   execute
 );
+
+cmdModule.rateLimit = 1000 * 60 * 10;
 export default cmdModule;

--- a/src/beastie/commands/informational/discord.ts
+++ b/src/beastie/commands/informational/discord.ts
@@ -8,4 +8,5 @@ const execute = async (context: CommandContext): Promise<string> => {
 };
 
 const cmdModule = new CommandModule("discord", new Set([]), execute);
+cmdModule.rateLimit = 1000 * 60 * 10;
 export default cmdModule;

--- a/src/beastie/commands/informational/trello.ts
+++ b/src/beastie/commands/informational/trello.ts
@@ -1,0 +1,9 @@
+import { CommandModule } from "../index";
+
+const execute = async (): Promise<string> => {
+  return `Check out the beastie trello => https://trello.com/b/WEzOBz2t/beastiebot`;
+};
+
+const cmdModule = new CommandModule("trello", new Set([]), execute);
+cmdModule.rateLimit = 1000 * 60 * 10;
+export default cmdModule;

--- a/src/beastie/commands/informational/twitch.ts
+++ b/src/beastie/commands/informational/twitch.ts
@@ -8,4 +8,5 @@ const execute = async (context: CommandContext): Promise<string> => {
 };
 
 const cmdModule = new CommandModule("twitch", new Set([]), execute);
+cmdModule.rateLimit = 1000 * 60 * 10;
 export default cmdModule;

--- a/src/services/discord/discordPosts.ts
+++ b/src/services/discord/discordPosts.ts
@@ -1,12 +1,16 @@
 import { POST_EVENT } from "../../utils/values";
-import { getBroadcasterDisplayName } from "../../utils";
+import { broadcaster } from "../twitch/TwitchAPI";
 
 const discordPosts = async (event, memberUser = "") => {
   switch (event) {
     case POST_EVENT.DISCORD_MEMBER_ADD:
       return postGuildMemberAdd(memberUser);
     case POST_EVENT.LIVE:
-      const broadcasterDisplayName = await getBroadcasterDisplayName();
+      const broadcasterDisplayName = (await broadcaster.getProfile())
+        ?.display_name;
+      if (!broadcasterDisplayName) {
+        throw "Failed to get broadcaster display name";
+      }
       return postLive(broadcasterDisplayName);
     default:
       return;

--- a/src/services/twitch/TwitchAPI/apiTypes.ts
+++ b/src/services/twitch/TwitchAPI/apiTypes.ts
@@ -1,0 +1,47 @@
+export type TwitchProfile = {
+  id: string;
+  login: string;
+  display_name: string;
+  type: string;
+  broadcaster_type: string;
+  description: string;
+  profile_image_url: string;
+  offline_image_url: string;
+  view_count: number;
+  email: string;
+};
+
+export type TwitchChatters = {
+  broadcaster: string[];
+  vips: string[];
+  moderators: string[];
+  staff: string[];
+  admins: string[];
+  global_mods: string[];
+  viewers: string[];
+};
+
+export type TwitchChattersData = {
+  links: any;
+  chatter_count: number;
+  chatters: TwitchChatters;
+};
+
+export type TwitchStream = {
+  id: string;
+  user_id: string;
+  user_name: string;
+  game_id: string;
+  type: string;
+  title: string;
+  viewer_count: number;
+  started_at: string;
+  language: string;
+  thumbnail_url: string;
+  tag_ids: string[];
+};
+
+export type TwitchStreams = {
+  data: TwitchStream[];
+  pagination: any; // idk what this is but twitch includes it in the response (never seen it with any data)
+};

--- a/src/services/twitch/TwitchAPI/apiTypes.ts
+++ b/src/services/twitch/TwitchAPI/apiTypes.ts
@@ -11,6 +11,10 @@ export type TwitchProfile = {
   email: string;
 };
 
+export type TwitchUsersReturnData = {
+  data: TwitchProfile[];
+};
+
 export type TwitchChatters = {
   broadcaster: string[];
   vips: string[];
@@ -21,7 +25,7 @@ export type TwitchChatters = {
   viewers: string[];
 };
 
-export type TwitchChattersData = {
+export type TwitchChattersReturnData = {
   links: any;
   chatter_count: number;
   chatters: TwitchChatters;
@@ -41,7 +45,7 @@ export type TwitchStream = {
   tag_ids: string[];
 };
 
-export type TwitchStreams = {
+export type TwitchStreamsReturnData = {
   data: TwitchStream[];
   pagination: any; // idk what this is but twitch includes it in the response (never seen it with any data)
 };

--- a/src/services/twitch/TwitchAPI/apiTypes.ts
+++ b/src/services/twitch/TwitchAPI/apiTypes.ts
@@ -47,5 +47,5 @@ export type TwitchStream = {
 
 export type TwitchStreamsReturnData = {
   data: TwitchStream[];
-  pagination: any; // idk what this is but twitch includes it in the response (never seen it with any data)
+  pagination: any; // We don't currently use this but it's an iterator for the streams
 };

--- a/src/services/twitch/TwitchAPI/endpoints.ts
+++ b/src/services/twitch/TwitchAPI/endpoints.ts
@@ -1,31 +1,43 @@
-import { TwitchChattersData, TwitchProfile, TwitchStreams } from "./apiTypes";
+import {
+  TwitchChatters,
+  TwitchChattersReturnData,
+  TwitchProfile,
+  TwitchStream,
+  TwitchStreamsReturnData,
+  TwitchUsersReturnData
+} from "./apiTypes";
 import config from "../../../config";
-import { PerformHttpRequest } from "../../../utils";
+import { PerformGetRequest } from "../../../utils";
 
-function callTwitchApi<T>(uri, options = null): Promise<T> {
-  options = options || {};
-  options.headers = {
-    "Client-ID": `${config.CLIENT_ID}`,
-    Authorization: `Bearer ${config.BROADCASTER_OAUTH}`
+function callTwitchApi<T>(uri, headers = {}): Promise<T> {
+  let httpHeaders = {
+    ...{
+      "Content-Type": "application/json",
+      "Client-ID": `${config.CLIENT_ID}`,
+      Authorization: `Bearer ${config.BROADCASTER_OAUTH}`
+    },
+    ...headers
   };
-  options.json = true;
-  return PerformHttpRequest<T>(uri, options);
+  return PerformGetRequest<T>(uri, httpHeaders);
 }
 
-export async function helixUsers(query: string): Promise<TwitchProfile[]> {
-  return callTwitchApi<TwitchProfile[]>(
-    `https://api.twitch.tv/helix/users?${query}`
-  );
-}
+export const helixUsers = async (query: string): Promise<TwitchProfile[]> =>
+  (
+    await callTwitchApi<TwitchUsersReturnData>(
+      `https://api.twitch.tv/helix/users?${query}`
+    )
+  ).data;
 
-export async function helixStreams(query: string): Promise<TwitchStreams> {
-  return callTwitchApi(`https://api.twitch.tv/helix/streams?${query}`);
-}
+export const helixStreams = async (query: string): Promise<TwitchStream[]> =>
+  (
+    await callTwitchApi<TwitchStreamsReturnData>(
+      `https://api.twitch.tv/helix/streams?${query}`
+    )
+  ).data;
 
-export async function tmiChatters(
-  streamer: string
-): Promise<TwitchChattersData> {
-  return callTwitchApi<TwitchChattersData>(
-    `https://tmi.twitch.tv/group/user/${streamer}/chatters`
-  );
-}
+export const tmiChatters = async (streamer: string): Promise<TwitchChatters> =>
+  (
+    await callTwitchApi<TwitchChattersReturnData>(
+      `https://tmi.twitch.tv/group/user/${streamer}/chatters`
+    )
+  ).chatters;

--- a/src/services/twitch/TwitchAPI/endpoints.ts
+++ b/src/services/twitch/TwitchAPI/endpoints.ts
@@ -18,7 +18,7 @@ function callTwitchApi<T>(uri, headers = {}): Promise<T> {
     },
     ...headers
   };
-  return PerformGetRequest<T>(uri, httpHeaders);
+  return performGetRequest<T>(uri, httpHeaders);
 }
 
 export const helixUsers = async (query: string): Promise<TwitchProfile[]> =>

--- a/src/services/twitch/TwitchAPI/endpoints.ts
+++ b/src/services/twitch/TwitchAPI/endpoints.ts
@@ -7,7 +7,7 @@ import {
   TwitchUsersReturnData
 } from "./apiTypes";
 import config from "../../../config";
-import { PerformGetRequest } from "../../../utils";
+import { performGetRequest } from "../../../utils";
 
 function callTwitchApi<T>(uri, headers = {}): Promise<T> {
   let httpHeaders = {

--- a/src/services/twitch/TwitchAPI/endpoints.ts
+++ b/src/services/twitch/TwitchAPI/endpoints.ts
@@ -1,0 +1,31 @@
+import { TwitchChattersData, TwitchProfile, TwitchStreams } from "./apiTypes";
+import config from "../../../config";
+import { PerformHttpRequest } from "../../../utils";
+
+function callTwitchApi<T>(uri, options = null): Promise<T> {
+  options = options || {};
+  options.headers = {
+    "Client-ID": `${config.CLIENT_ID}`,
+    Authorization: `Bearer ${config.BROADCASTER_OAUTH}`
+  };
+  options.json = true;
+  return PerformHttpRequest<T>(uri, options);
+}
+
+export async function helixUsers(query: string): Promise<TwitchProfile[]> {
+  return callTwitchApi<TwitchProfile[]>(
+    `https://api.twitch.tv/helix/users?${query}`
+  );
+}
+
+export async function helixStreams(query: string): Promise<TwitchStreams> {
+  return callTwitchApi(`https://api.twitch.tv/helix/streams?${query}`);
+}
+
+export async function tmiChatters(
+  streamer: string
+): Promise<TwitchChattersData> {
+  return callTwitchApi<TwitchChattersData>(
+    `https://tmi.twitch.tv/group/user/${streamer}/chatters`
+  );
+}

--- a/src/services/twitch/TwitchAPI/index.ts
+++ b/src/services/twitch/TwitchAPI/index.ts
@@ -1,0 +1,96 @@
+// Takes in an array of usernames and converts to an array of
+// queries for the twitch helix api limiting to 100 users per
+// query.
+import { Cache, CacheKeyValPair } from "../../../utils/cache";
+import { TwitchProfile, TwitchStream } from "./apiTypes";
+import { BeastieLogger } from "../../../utils/Logging";
+import { helixStreams, helixUsers, tmiChatters } from "./endpoints";
+import config from "../../../config";
+
+function usernameArrayToIdQueryArray(usernames: string[]): string[] {
+  const arraysOfUsernames = usernames
+    .reduce(
+      ([_ = [], ...rest], username) =>
+        _.length < 100 ? [[..._, username], ...rest] : [[username], _, ...rest],
+      []
+    )
+    .reverse();
+
+  return arraysOfUsernames.map(
+    usernames => `login=${usernames.join("&login=")}`
+  );
+}
+
+let profileCache: Cache<TwitchProfile> = new Cache<TwitchProfile>(
+  async (
+    key: string | string[]
+  ): Promise<TwitchProfile | CacheKeyValPair<TwitchProfile>[]> => {
+    if (Array.isArray(key)) {
+      let profileKeyValuePairs: CacheKeyValPair<TwitchProfile>[] = [];
+      for (const query of usernameArrayToIdQueryArray(key)) {
+        try {
+          profileKeyValuePairs = profileKeyValuePairs.concat(
+            Array.from(await helixUsers(query), profile => ({
+              key: profile.login,
+              val: profile
+            }))
+          );
+        } catch (e) {
+          BeastieLogger.warn(`Failed to fetch twitch user ${query}`);
+        }
+      }
+      return profileKeyValuePairs;
+    } else {
+      return (await helixUsers(`login=${key}`))[0];
+    }
+  }
+);
+
+export async function getTwitchProfile(
+  username: string
+): Promise<TwitchProfile> {
+  try {
+    return (await profileCache.get(username)) as TwitchProfile;
+  } catch (e) {
+    BeastieLogger.warn(`Failed to get twitch user ${username}: ${e}`);
+  }
+  return null;
+}
+
+export async function getTwitchProfiles(
+  usernames: string[]
+): Promise<TwitchProfile[]> {
+  try {
+    return (await profileCache.get(usernames)) as TwitchProfile[];
+  } catch (e) {
+    BeastieLogger.warn(`Failed to get twitch user ${usernames}: ${e}`);
+  }
+  return null;
+}
+
+export const getTwitchChatters = async (
+  streamer: string
+): Promise<TwitchProfile[]> => {
+  const chatters = (await tmiChatters(streamer)).chatters;
+  return getTwitchProfiles(Object.values(chatters).flat());
+};
+
+export const isBroadcaster = (name: string) => {
+  return name === config.BROADCASTER_USERNAME;
+};
+
+type Broadcaster = {
+  getProfile: () => Promise<TwitchProfile>;
+  getStream: () => Promise<TwitchStream>;
+};
+
+export const broadcaster: Broadcaster = {
+  getProfile: async (): Promise<TwitchProfile> =>
+    await getTwitchProfile(config.BROADCASTER_USERNAME),
+  getStream: async (): Promise<TwitchStream> => {
+    let streams = await helixStreams(
+      `first=1&user_id=${(await broadcaster.getProfile())?.id}`
+    );
+    return streams[0];
+  }
+};

--- a/src/services/twitch/TwitchAPI/index.ts
+++ b/src/services/twitch/TwitchAPI/index.ts
@@ -3,7 +3,7 @@
 // query.
 import { Cache, CacheKeyValPair } from "../../../utils/cache";
 import { TwitchProfile, TwitchStream } from "./apiTypes";
-import { BeastieLogger, tryCatchLog } from "../../../utils/Logging";
+import { BeastieLogger, swallowRejection } from "../../../utils/Logging";
 import { helixStreams, helixUsers, tmiChatters } from "./endpoints";
 import config from "../../../config";
 
@@ -49,20 +49,14 @@ let profileCache: Cache<TwitchProfile> = new Cache<TwitchProfile>(
 export const getTwitchProfile = async (
   username: string
 ): Promise<TwitchProfile> =>
-  tryCatchLog(
-    async () => (await profileCache.get(username)) as TwitchProfile,
-    BeastieLogger.warn,
-    `Failed to get twitch user ${username}`
-  );
+  (profileCache.get(username) as Promise<TwitchProfile>)
+    .catch(swallowRejection(`Failed to get twitch user ${username}`, BeastieLogger.warn));
 
 export const getTwitchProfiles = async (
   usernames: string[]
 ): Promise<TwitchProfile[]> =>
-  tryCatchLog<TwitchProfile[]>(
-    async () => (await profileCache.get(usernames)) as TwitchProfile[],
-    BeastieLogger.warn,
-    `Failed to get twitch user ${usernames}`
-  );
+  (profileCache.get(usernames) as Promise<TwitchProfile[]>)
+    .catch(swallowRejection(`Failed to get twitch user ${usernames}`, BeastieLogger.warn));
 
 export const getTwitchChatters = async (
   streamer: string

--- a/src/services/twitch/index.ts
+++ b/src/services/twitch/index.ts
@@ -37,7 +37,7 @@ export default class BeastieTwitchService {
   discordInterval: NodeJS.Timeout;
 
   messageQueue: string[] = [];
-  messageQueueLimit: number = 1000 * 0.2;
+  messageQueueLimit: number = 1000 * 1.5;
   messageQueueTimeout: NodeJS.Timeout = null;
 
   constructor() {

--- a/src/services/twitter/index.ts
+++ b/src/services/twitter/index.ts
@@ -49,7 +49,7 @@ export default class BeastieTwitterClient {
     );
   };
 
-  public post = async (event, streamId = 0) => {
+  public post = async (event, streamId: string = "0") => {
     const msg = await twitterPosts(event, streamId);
     this.say(msg);
   };

--- a/src/services/twitter/twitterPosts.ts
+++ b/src/services/twitter/twitterPosts.ts
@@ -1,17 +1,21 @@
-import { getBroadcasterDisplayName } from "../../utils";
 import { POST_EVENT } from "../../utils/values";
+import { broadcaster } from "../twitch/TwitchAPI";
 
-const twitterPosts = async (event, streamId) => {
+const twitterPosts = async (event, streamId: string) => {
   switch (event) {
     case POST_EVENT.LIVE:
-      const broadcasterDisplayName = await getBroadcasterDisplayName();
+      const broadcasterDisplayName = (await broadcaster.getProfile())
+        ?.display_name;
+      if (!broadcasterDisplayName) {
+        throw "Failed to get streamer display_name";
+      }
       return postLive(broadcasterDisplayName, streamId);
     default:
       return;
   }
 };
 
-const postLive = (broadcaster, streamId) => {
+const postLive = (broadcaster: string, streamId: string) => {
   return `BeastieBot is rawring because we are LIVE! RAWR https://www.twitch.tv/${broadcaster}#stream-${streamId} #${broadcaster} #GameDev #WebDev`;
 };
 

--- a/src/utils/Logging.ts
+++ b/src/utils/Logging.ts
@@ -44,17 +44,13 @@ if (process.env.NODE_ENV !== "production") {
   );
 }
 
-export async function tryCatchLog<T>(
-  func: () => Promise<T>,
-  logFunction,
-  outputOnFail
-): Promise<T> {
-  try {
-    return await func();
-  } catch (e) {
-    logFunction(`${outputOnFail}: ${e}`);
-  }
-  return null;
+export function swallowRejection(
+    errorMessage: string,
+    errorLog: (message: string) => void = BeastieLogger.error
+): (rejection: any) => Promise<null> {
+    return async (error: any) => {
+        await errorLog(`${errorMessage}: ${JSON.stringify(error)}`);
+        return null;
+    };
 }
-
 export { beastieLogger as BeastieLogger };

--- a/src/utils/Logging.ts
+++ b/src/utils/Logging.ts
@@ -44,4 +44,17 @@ if (process.env.NODE_ENV !== "production") {
   );
 }
 
+export async function tryCatchLog<T>(
+  func: () => Promise<T>,
+  logFunction,
+  outputOnFail
+): Promise<T> {
+  try {
+    return await func();
+  } catch (e) {
+    logFunction(`${outputOnFail}: ${e}`);
+  }
+  return null;
+}
+
 export { beastieLogger as BeastieLogger };

--- a/src/utils/Logging.ts
+++ b/src/utils/Logging.ts
@@ -45,12 +45,12 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export function swallowRejection(
-    errorMessage: string,
-    errorLog: (message: string) => void = BeastieLogger.error
+  errorMessage: string,
+  errorLog: (message: string) => void = beastieLogger.error
 ): (rejection: any) => Promise<null> {
-    return async (error: any) => {
-        await errorLog(`${errorMessage}: ${JSON.stringify(error)}`);
-        return null;
-    };
+  return async (error: any) => {
+    await errorLog(`${errorMessage}: ${JSON.stringify(error)}`);
+    return null;
+  };
 }
 export { beastieLogger as BeastieLogger };

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,86 @@
+import Timeout = NodeJS.Timeout;
+
+export type CacheKeyValPair<T> = {
+  key: string;
+  val: T;
+};
+
+export class Cache<T> {
+  timeoutArray: Timeout[] = [];
+  private storage: Map<string, T> = new Map<string, T>();
+  private readonly fetch: (
+    key: string | string[]
+  ) => Promise<T | CacheKeyValPair<T>[]>;
+  private readonly clearTime: number;
+
+  // Default clear time of 24 hours
+  constructor(
+    fetchFunc: (key: string | string[]) => Promise<T | CacheKeyValPair<T>[]>,
+    clearTime: number = 1000 * 60 * 60 * 24
+  ) {
+    this.fetch = fetchFunc;
+    this.clearTime = clearTime;
+  }
+
+  async get(key: string | string[]): Promise<T | T[]> {
+    return await (Array.isArray(key)
+      ? this.getArray(key)
+      : this.getSingle(key));
+  }
+
+  private addToCache(key: string, val: T) {
+    this.storage.set(key, val);
+    let timeoutId = setTimeout(() => {
+      this.storage.delete(key);
+      for (let i = 0; i < this.timeoutArray.length; i++) {
+        if (this.timeoutArray[i] === timeoutId) {
+          this.timeoutArray.splice(i, 1);
+          break;
+        }
+      }
+    }, this.clearTime);
+    this.timeoutArray.push(timeoutId);
+  }
+
+  private async getSingle(key: string): Promise<T> {
+    if (this.storage.has(key)) {
+      return this.storage.get(key);
+    }
+    let val: T = (await this.fetch(key)) as T;
+
+    if (val === null) {
+      throw `Failed to fetch ${key}`;
+    }
+
+    this.addToCache(key, val);
+    return val;
+  }
+
+  private async getArray(keys: string[]): Promise<T[]> {
+    let retVals: T[] = [];
+
+    keys = keys.filter((key: string): boolean => {
+      if (!this.storage.has(key)) {
+        return true;
+      }
+
+      retVals.push(this.storage.get(key));
+      return false;
+    });
+
+    let vals: CacheKeyValPair<T>[] = (await this.fetch(
+      keys
+    )) as CacheKeyValPair<T>[];
+
+    if (vals === null) {
+      throw `Failed to fetch ${JSON.stringify(keys)}`;
+    }
+
+    vals.forEach(kvPair => {
+      this.addToCache(kvPair.key, kvPair.val);
+      retVals.push(kvPair.val);
+    });
+
+    return retVals;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ import {
 } from "../services/twitch/TwitchAPI";
 import { default as fetch, RequestInfo } from "node-fetch";
 
-export async function PerformGetRequest<T>(
+export async function performGetRequest<T>(
   url: RequestInfo,
   headers: object = {}
 ): Promise<T> {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,196 +1,61 @@
-import rp from "request-promise";
 import config from "../config";
-import { BeastieLogger } from "./Logging";
+import { BeastieLogger, tryCatchLog } from "./Logging";
 import { updateAwesomeness } from "../services/db";
+import { TwitchProfile } from "../services/twitch/TwitchAPI/apiTypes";
+import {
+  getTwitchChatters,
+  getTwitchProfile
+} from "../services/twitch/TwitchAPI";
+import { default as fetch, RequestInfo, RequestInit } from "node-fetch";
 
-function callTwitchApi(uri, options) {
-  options = options || {};
-  options.headers = {
-    "Client-ID": `${config.CLIENT_ID}`,
-    Authorization: `Bearer ${config.BROADCASTER_OAUTH}`
-  };
-  options.json = true;
-  options.uri = uri;
-  return rp(options);
+export async function PerformHttpRequest<T>(
+  url: RequestInfo,
+  init?: RequestInit
+): Promise<T> {
+  const response = await fetch(url, init);
+  return await response.json();
 }
 
 export const isGuildMaster = name => {
   return name === config.DISCORD_GUILD_MASTER_USERNAME;
 };
 
-export const isBroadcaster = name => {
-  return name === config.BROADCASTER_USERNAME;
-};
-
-type TwitchProfile = {
-  id: string;
-  login: string;
-  display_name: string;
-  type: string;
-  broadcaster_type: string;
-  description: string;
-  profile_image_url: string;
-  offline_image_url: string;
-  view_count: number;
-};
-
-let twitchProfileCache = new Map<string, TwitchProfile>();
-
-function addProfileToCache(
-  username: string,
-  profile: TwitchProfile
-): TwitchProfile {
-  if (twitchProfileCache.has(username)) {
-    return profile;
-  }
-  twitchProfileCache.set(username, profile);
-  setTimeout(() => twitchProfileCache.delete(username), 1000 * 60 * 60 * 24);
-  return profile;
-}
-
-const getTwitchProfile = async (username: string): Promise<TwitchProfile> => {
-  if (twitchProfileCache.has(username)) {
-    return twitchProfileCache.get(username);
-  }
-
-  try {
-    const {
-      data: [profile = null]
-    } = await callTwitchApi("https://api.twitch.tv/helix/users", {
-      qs: { login: username.toLowerCase() }
-    });
-    return addProfileToCache(username, profile);
-  } catch (e) {
-    BeastieLogger.warn(`Failed to get twitch user ${username}: ${e}`);
-  }
-
-  return null;
-};
-
-export const getTwitchId = async (username: string): Promise<string> => {
-  let user = await getTwitchProfile(username);
-  return user?.id;
-};
-
-export const getBroadcasterId = async (): Promise<string> => {
-  return getTwitchId(config.BROADCASTER_USERNAME);
-};
-
-export const getBroadcasterDisplayName = async () => {
-  const userArray = await getTwitchProfile(config.BROADCASTER_USERNAME);
-  return userArray?.display_name;
-};
-
-const getBroadcasterStream = async broadcasterID => {
-  return callTwitchApi(
-    `https://api.twitch.tv/helix/streams?first=1&user_id=${broadcasterID}`,
-    {}
-  );
-};
-
-export const initStream = async () => {
-  const broadcasterID = await getBroadcasterId();
-  const stream = await getBroadcasterStream(broadcasterID);
-
-  const live = stream.data[0] && stream.data[0].type === "live";
-  const id = stream.data[0] && stream.data[0].id;
-
-  return { live, id };
-};
-
-type ChattersData = {
-  broadcaster?: string[];
-  vips?: string[];
-  moderators: string[];
-  staff: string[];
-  admins: string[];
-  global_mods: string[];
-  viewers: string[];
-};
-
-async function getTwitchProfiles(usernames: string[]) {
-  let twitchProfiles: TwitchProfile[] = [];
-
-  usernames = usernames.filter((username: string): boolean => {
-    if (!twitchProfileCache.has(username)) {
-      return true;
-    }
-
-    twitchProfiles.push(twitchProfileCache.get(username));
-    return false;
-  });
-
-  const arraysOfUsernames = usernames
-    .reduce(
-      ([_ = [], ...rest], username) =>
-        _.length < 100 ? [[..._, username], ...rest] : [[username], _, ...rest],
-      []
-    )
-    .reverse();
-
-  const userIdQueryStrings = arraysOfUsernames.map(
-    usernames => `login=${usernames.join("&login=")}`
+export const updateTeammateAwesomeness = async (
+  user,
+  amount
+): Promise<string> => {
+  let profile: TwitchProfile = await tryCatchLog<TwitchProfile>(
+    async () => getTwitchProfile(user),
+    BeastieLogger.warn,
+    `Failed to get twitch profile for ${user}`
   );
 
-  for (const query of userIdQueryStrings) {
-    try {
-      const { data: profiles = [] } = await callTwitchApi(
-        `https://api.twitch.tv/helix/users?${query}`,
-        {}
-      );
-
-      profiles.forEach((profile: TwitchProfile) => {
-        twitchProfiles.push(addProfileToCache(profile.login, profile));
-      });
-    } catch (e) {
-      BeastieLogger.warn(`Failed to fetch twitch user ${query}`);
-    }
-  }
-  return twitchProfiles;
-}
-
-const getChatroomViewers = async (): Promise<TwitchProfile[]> => {
-  let chatters: ChattersData;
-  try {
-    chatters = (
-      await callTwitchApi(
-        `https://tmi.twitch.tv/group/user/${config.BROADCASTER_USERNAME}/chatters`,
-        {}
-      )
-    ).chatters;
-  } catch (e) {
-    BeastieLogger.warn(`Failed to get chatroom viewers: ${e}`);
-    return [];
-  }
-
-  return getTwitchProfiles(Object.values(chatters).flat());
-};
-
-export const updateTeammateAwesomeness = async (user, amount) => {
-  const twitchUser = await getTwitchProfile(user);
-
-  if (!twitchUser) {
+  if (!profile) {
     return `I cannot find that username...`;
   }
 
-  if (!(await updateAwesomeness(twitchUser.id, twitchUser.login, amount))) {
+  if (!(await updateAwesomeness(profile.id, profile.login, amount))) {
     return `I failed to update the awesomeness :(`;
   }
 
   BeastieLogger.info(
-    `AWESOMENESS: ${twitchUser.display_name} received ${amount} awesomeness`
+    `AWESOMENESS: ${profile.display_name} received ${amount} awesomeness`
   );
-  return `Awarded ${twitchUser.display_name} ${amount} Awesomeness!`;
+  return `Awarded ${profile.display_name} ${amount} Awesomeness!`;
 };
 
-export const updateChattersAwesomeness = async amount => {
-  let viewers: TwitchProfile[];
-  try {
-    viewers = await getChatroomViewers();
-  } catch (e) {
-    BeastieLogger.warn(`Failed to get chatroom viewers!`);
-    return;
+export const updateChattersAwesomeness = async (
+  amount: number
+): Promise<string> => {
+  if (isNaN(amount)) {
+    return `I don't think that is a number o.o`;
   }
+
+  let viewers: TwitchProfile[] = await tryCatchLog<TwitchProfile[]>(
+    async () => getTwitchChatters(config.BROADCASTER_USERNAME),
+    BeastieLogger.warn,
+    "Failed to get chatroom viewers"
+  );
   BeastieLogger.debug(`Current viewers: ${viewers}`);
 
   if (!viewers) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,19 +6,22 @@ import {
   getTwitchChatters,
   getTwitchProfile
 } from "../services/twitch/TwitchAPI";
-import { default as fetch, RequestInfo, RequestInit } from "node-fetch";
+import { default as fetch, RequestInfo } from "node-fetch";
 
-export async function PerformHttpRequest<T>(
+export async function PerformGetRequest<T>(
   url: RequestInfo,
-  init?: RequestInit
+  headers: object = {}
 ): Promise<T> {
-  const response = await fetch(url, init);
+  const response = await fetch(url, {
+    method: "GET",
+    headers: headers
+  });
+
   return await response.json();
 }
 
-export const isGuildMaster = name => {
-  return name === config.DISCORD_GUILD_MASTER_USERNAME;
-};
+export const isGuildMaster = name =>
+  name === config.DISCORD_GUILD_MASTER_USERNAME;
 
 export const updateTeammateAwesomeness = async (
   user,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import config from "../config";
-import { BeastieLogger, tryCatchLog } from "./Logging";
+import { BeastieLogger, swallowRejection } from "./Logging";
 import { updateAwesomeness } from "../services/db";
 import { TwitchProfile } from "../services/twitch/TwitchAPI/apiTypes";
 import {
@@ -27,11 +27,8 @@ export const updateTeammateAwesomeness = async (
   user,
   amount
 ): Promise<string> => {
-  let profile: TwitchProfile = await tryCatchLog<TwitchProfile>(
-    async () => getTwitchProfile(user),
-    BeastieLogger.warn,
-    `Failed to get twitch profile for ${user}`
-  );
+  let profile: TwitchProfile = await (getTwitchProfile(user) as Promise<TwitchProfile>)
+    .catch(swallowRejection(`Failed to get twitch profile for ${user}`, BeastieLogger.warn));
 
   if (!profile) {
     return `I cannot find that username...`;
@@ -54,11 +51,8 @@ export const updateChattersAwesomeness = async (
     return `I don't think that is a number o.o`;
   }
 
-  let viewers: TwitchProfile[] = await tryCatchLog<TwitchProfile[]>(
-    async () => getTwitchChatters(config.BROADCASTER_USERNAME),
-    BeastieLogger.warn,
-    "Failed to get chatroom viewers"
-  );
+  let viewers: TwitchProfile[] = await (getTwitchChatters(config.BROADCASTER_USERNAME) as Promise<TwitchProfile[]>)
+    .catch(swallowRejection("Failed to get chatroom viewers", BeastieLogger.warn));
   BeastieLogger.debug(`Current viewers: ${viewers}`);
 
   if (!viewers) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,27 +56,28 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.1.tgz#5d93e0a099cd0acd5ef3d5bde3c086e1f49ff68c"
-  integrity sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.4.tgz#43a63fc5edce226bed106b31b875165256271107"
+  integrity sha512-k3NqigXWRzQZVBDS5D1U70A5E8Qk4Kh+Ha/x4M8Bt9pF0X05eggfnC9+63Usc9Q928hRUIpIhTQaXsZwZBl4Ew==
 
 "@types/node@^12.0.6":
-  version "12.12.39"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.39.tgz#532d25c1e639d89dd6f3aa1d7b3962e3e7fa943d"
-  integrity sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==
+  version "12.12.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.41.tgz#cf48562b53ab6cf85d28dde95f1d06815af275c8"
+  integrity sha512-Q+eSkdYQJ2XK1AJnr4Ji8Gvk3sRDybEwfTvtL9CA25FFUSD2EgZQewN6VCyWYZCXg5MWZdwogdTNBhlWRcWS1w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
-
-"@types/request-promise-native@^1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@types/request-promise-native/-/request-promise-native-1.0.17.tgz#74a2d7269aebf18b9bdf35f01459cf0a7bfc7fab"
-  integrity sha512-05/d0WbmuwjtGMYEdHIBZ0tqMJJQ2AD9LG2F6rKNBGX1SSFR27XveajH//2N/XYtual8T9Axwl+4v7oBtPUZqg==
-  dependencies:
-    "@types/request" "*"
 
 "@types/request@*":
   version "2.48.5"
@@ -259,9 +260,9 @@ atob@^2.1.2:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sdk@^2.678.0:
-  version "2.678.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.678.0.tgz#b16230f4894d40ead50f9e23805c874f4ca62549"
-  integrity sha512-i8t7+1/C6maQzUYUFRQXPAsUPT0YdpNsf/oHZKmmZrsOX+epnn2jmAGIBTZgUakY8jRrZxCJka+QokUIadUVQg==
+  version "2.681.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.681.0.tgz#09eeedb5ca49813dfc637908abe408ae114a6824"
+  integrity sha512-/p8CDJ7LZvB1i4WrJrb32FUbbPdiZFZSN6FI2lv7s/scKypmuv/iJ9kpx6QWSWQZ72kJ3Njk/0o7GuVlw0jHXw==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -785,6 +786,13 @@ enabled@1.0.x:
   dependencies:
     env-variable "0.0.x"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -1001,6 +1009,15 @@ form-data@^2.5.0:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -1179,6 +1196,13 @@ husky@^2.4.0:
     read-pkg "^5.1.1"
     run-node "^1.0.0"
     slash "^3.0.0"
+
+iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
@@ -1412,7 +1436,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -1751,6 +1775,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^1.1.0:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-fetch@^2.6.0:
   version "2.6.0"
@@ -2227,15 +2259,6 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
-  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
-  dependencies:
-    request-promise-core "1.1.3"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
 request-promise@^4.2.2:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.5.tgz#186222c59ae512f3497dfe4d75a9c8461bd0053c"
@@ -2272,7 +2295,7 @@ request@2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.72.0, request@^2.83.0, request@^2.88.2:
+request@^2.72.0, request@^2.83.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -2359,7 +2382,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -2790,9 +2813,9 @@ type-fest@^0.6.0:
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 typescript@^3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
-  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 undefsafe@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
Moved all TwitchAPI related types into "TwitchAPI/apiTypes"
Replaced "request-promise" with "node-fetch"
Updated "updateChattersAwesomeness" argument to number
Created "Cache" class
Changed curStreamId to string
Changed messageQueueLimit to 1.5s to minimum limit
Added "tryCatchLog" to Logger to reduce duplicate code
yarn.lock updated
Info commands now have a rate limit of 10 minutes
Added trello command
Renamed api types to differentiate what is returned from the API
Rearranged endpoints to implement more one liners - sorry not sorry
Changed callTwitchApi options to headers object
More one liners in TwitchAPI
Less repeating "try -> do thing -> catch with log"
Fixed fetch calls to use proper options and specify headers